### PR TITLE
Link repo files into the OS

### DIFF
--- a/.github/workflows/login.yml
+++ b/.github/workflows/login.yml
@@ -31,14 +31,14 @@ jobs:
         run: |
           find . \( -name .git \) -prune -o -type f -exec grep -z -l -P '^#![^\r\n]+/bash' '{}' \; | xargs -n 1 -I '{}' shellcheck --severity=error "{}"
           find . \( -name .git \) -prune -o -type f -exec grep -z -l -P '^#![^\r\n]+/zsh' '{}' \; | xargs -n 1 -I '{}' zsh -n "{}"
+      - name: Install cluster configurations
+        run: sudo ./install.sh login
 
       - name: Check sudoers
         run: set nullglob visudo --check --strict login/etc/sudoers.d/*
 
       - name: Systemd unit files
         run: |
-          # systemd will check if the executables refered by the service files exist
-          sudo cp login/usr/local/bin/* /usr/local/bin/
           cd login/etc/systemd/system/
           # cannot use option `--user` because it throws error "Failed to initialize manager: No such device or address"
           sudo systemd-analyze verify *

--- a/.github/workflows/login.yml
+++ b/.github/workflows/login.yml
@@ -33,6 +33,8 @@ jobs:
           find . \( -name .git \) -prune -o -type f -exec grep -z -l -P '^#![^\r\n]+/zsh' '{}' \; | xargs -n 1 -I '{}' zsh -n "{}"
       - name: Install cluster configurations
         run: sudo ./install.sh login
+      - name: Check motd
+        run: sudo run-parts login/etc/update-motd.d/
 
       - name: Check sudoers
         run: set nullglob visudo --check --strict login/etc/sudoers.d/*

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/zsh
 
+if [[ -z $1 ]] || [[ ! -d $1 ]]; then
+	echo "Usage:\n$0 folder" >&2
+	exit 1
+fi
 
-
+foldersToCopy=(etc/systemd etc/security/limits.d)
 
 function needCopy()
 {
-	foldersToCopy=(etc/systemd)
 	file=$1
 	for folder in $foldersToCopy
 	do
@@ -20,9 +23,11 @@ function needCopy()
 untrackedFiles=$(git status -uall --short --porcelain | awk '$1==''"??"'' {print $2}')
 
 
+cd $1
 for file in **/*(.)
 do
-	if [[ $0 = *$file ]]; then
+	bn=$(basename $file)
+	if [[ install.sh  = $bn ]]; then
 		echo "skip install file"
 		continue
 	fi

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,8 @@
 
 if [[ -z $1 ]] || [[ ! -d $1 ]]; then
 	echo "Usage:\n$0 folder" >&2
+	echo "\nIf the current machine is a compute node, run '$0 compute'." >&2
+	echo "If the current machine is a login node, run '$0 login'." >&2
 	exit 1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,26 @@ if [[ -z $1 ]] || [[ ! -d $1 ]]; then
 	exit 1
 fi
 
+
+function loginInstall
+{
+	# checkConnections is guaranteed to exist because it's from this repo.
+	if grep -E '^session\s+required\s+pam_exec.so\s+stdout\s+/usr/libexec/checkConnections\s+10' /etc/pam.d/sshd > /dev/null; then
+		echo 'not install checkConnections again.'
+	else
+		echo 'session required pam_exec.so stdout /usr/libexec/checkConnections 10' >> /etc/pam.d/sshd
+	fi
+
+	mkdir /etc/daily-tips
+}
+
+
+case $1 in
+	login)
+		loginInstall
+		;;
+esac
+
 foldersToCopy=(etc/systemd etc/security/limits.d)
 
 function needCopy()
@@ -47,13 +67,3 @@ do
 		ln -s $PWD/$file /$file
 	fi
 done
-
-if [[ -f /usr/libexec/checkConnections ]]; then
-	if grep -E '^session\s+required\s+pam_exec.so\s+stdout\s+/usr/libexec/checkConnections\s+10' /etc/pam.d/sshd > /dev/null; then
-		echo 'not install checkConnections again.'
-	else
-		echo 'session required pam_exec.so stdout /usr/libexec/checkConnections 10' >> /etc/pam.d/sshd
-	fi
-else
-	echo '/usr/libexec/checkConnections not found' >&2
-fi

--- a/login/install.sh
+++ b/login/install.sh
@@ -5,7 +5,7 @@
 
 function needCopy()
 {
-	foldersToCopy=()
+	foldersToCopy=(etc/systemd)
 	file=$1
 	for folder in $foldersToCopy
 	do


### PR DESCRIPTION
We want to copy, update, restore the configurations of our cluster nodes. The repository captures key configurations of the operating system. But how do the files in this repo been consumed by the OS?

The approach I implemented is to link repo files into the OS.

For example, we must install diskquota to path /usr/local/bin/diskquota. The implemented approach in this PR is that diskquota must be located in `login/usr/local/bin/diskquota`, and when `sudo ./install.sh login` is called, install.sh will link 
`/usr/local/bin/diskquota` to `login/usr/local/bin/diskquota`. That is, `usr/local/bin` should be a real Linux path existing in the OS.