### PR TITLE
Delete create aptuser group, and add dagobah,hoth into computerNodes

### DIFF
--- a/cluster-add-user/cluster-add-user.sh
+++ b/cluster-add-user/cluster-add-user.sh
@@ -33,12 +33,7 @@ sudo rm -rf /home/$username-tmp
 
 sudo ln -s /home/shared/$username /home/$username/shared
 
-# When user runs `srun` on aha, the user's groups are captured
-# on aha, then transfered to eureka. 
-# Although we put the user to group aptuser, the sudoers file doesn't
-# have corresponding rules so the user cannot run `sudo apt` on aha.
-# Eureka has the corresponding sudoers rule.
-sudo usermod -aG aptuser,conda-cache $username
+sudo usermod -aG conda-cache $username
 
 sudo -u $username cp ../slurm-examples/* /home/$username/shared/
 


### PR DESCRIPTION
Because now we no need aptuser group, so we do not create it for users.

And we use add dagobah and hoth nodes, instead of down eureka.